### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/yatan87/37ec586b-26a5-4af3-a854-28b96a578617/bb6e7e0a-7609-419d-b006-ce8073ee36b6/_apis/work/boardbadge/7cd1d28e-373d-43c7-8f0b-8d0730a0e90e)](https://dev.azure.com/yatan87/37ec586b-26a5-4af3-a854-28b96a578617/_boards/board/t/bb6e7e0a-7609-419d-b006-ce8073ee36b6/Microsoft.RequirementCategory)
 # birthofnations
 ![score](https://api.codiga.io/project/16824/score/svg) ![letterStatus](https://api.codiga.io/project/16824/status/svg)
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/yatan87/37ec586b-26a5-4af3-a854-28b96a578617/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.